### PR TITLE
feat: add CloudFront and S3 origin bucket

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -41,3 +41,7 @@ jobs:
       - name: Apply route53
         working-directory: terragrunt/env/production/route53
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply CDN
+        working-directory: terragrunt/env/production/cdn
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve        

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -26,7 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - module: route53
+          - module: cdn
+          - module: route53          
 
     runs-on: ubuntu-latest
     steps:

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,3 +1,5 @@
 skip-check:
+  - CKV2_AWS_32 # CloudFront: CDN appropriate response headers policy has been applied
   - CKV2_AWS_38 # Route53: DNS Secruity Extensions (DNSSEC) signing not required
+  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
   - CKV_AWS_86  # CloudFront: Access logging not required

--- a/terragrunt/aws/cdn/acm.tf
+++ b/terragrunt/aws/cdn/acm.tf
@@ -1,0 +1,41 @@
+resource "aws_acm_certificate" "cdn" {
+  provider = aws.us-east-1
+
+  domain_name               = var.domain_cdn
+  subject_alternative_names = ["*.${var.domain_cdn}"]
+  validation_method         = "DNS"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cdn_dns_validation" {
+  zone_id = var.hosted_zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.cdn.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cdn_certificate_validation" {
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.cdn.arn
+  validation_record_fqdns = [for record in aws_route53_record.cdn_dns_validation : record.fqdn]
+}

--- a/terragrunt/aws/cdn/cloudfront.tf
+++ b/terragrunt/aws/cdn/cloudfront.tf
@@ -1,0 +1,48 @@
+resource "aws_cloudfront_origin_access_identity" "cdn" {
+  comment = "CloudFront CDN for ${var.product_name}-${var.env}"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  enabled     = true
+  aliases     = [var.domain_cdn]
+  price_class = "PriceClass_All"
+
+  origin {
+    domain_name = module.cdn_origin.s3_bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.cdn.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    cache_policy_id            = local.cloudfront_cache_policy_optimized
+    origin_request_policy_id   = local.cloudfront_origin_request_policy_cors_s3origin
+    response_headers_policy_id = local.cloudfront_response_headers_policy_cors_preflight
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cdn_certificate_validation.certificate_arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}

--- a/terragrunt/aws/cdn/inputs.tf
+++ b/terragrunt/aws/cdn/inputs.tf
@@ -1,0 +1,4 @@
+variable "hosted_zone_id" {
+  description = "The hosted zone ID for the CDN DNS records"
+  type        = string
+}

--- a/terragrunt/aws/cdn/locals.tf
+++ b/terragrunt/aws/cdn/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized
+  cloudfront_cache_policy_optimized = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html#managed-origin-request-policy-cors-s3
+  cloudfront_origin_request_policy_cors_s3origin = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html#managed-response-headers-policies-cors-preflight
+  cloudfront_response_headers_policy_cors_preflight = "5cc3b908-e619-4b99-88e5-2cf7f45965bd"
+  s3_origin_id                                      = "s3-${var.product_name}-${var.env}"
+}

--- a/terragrunt/aws/cdn/s3.tf
+++ b/terragrunt/aws/cdn/s3.tf
@@ -1,0 +1,37 @@
+module "cdn_origin" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3"
+  bucket_name       = "${var.product_name}-${var.env}-cdn"
+  billing_tag_value = var.billing_code
+
+  versioning = {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_policy" "cdn_origin" {
+  bucket = module.cdn_origin.s3_bucket_id
+  policy = data.aws_iam_policy_document.cdn_origin_combined.json
+}
+
+data "aws_iam_policy_document" "cdn_origin_combined" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.cloudfront_get_object.json
+  ]
+}
+
+data "aws_iam_policy_document" "cloudfront_get_object" {
+  statement {
+    sid    = "CloudFrontGetObject"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.cdn.iam_arn]
+    }
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${module.cdn_origin.s3_bucket_arn}/*",
+    ]
+  }
+}

--- a/terragrunt/aws/route53/outputs.tf
+++ b/terragrunt/aws/route53/outputs.tf
@@ -1,0 +1,4 @@
+output "hosted_zone_id" {
+  description = "Route53 hosted zone ID that will hold our DNS records"
+  value       = aws_route53_zone.content_delivery_network.zone_id
+}

--- a/terragrunt/env/production/cdn/.terraform.lock.hcl
+++ b/terragrunt/env/production/cdn/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = ">= 4.9.0, ~> 4.66, < 5.0.0"
+  hashes = [
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terragrunt/env/production/cdn/terragrunt.hcl
+++ b/terragrunt/env/production/cdn/terragrunt.hcl
@@ -1,0 +1,25 @@
+terraform {
+  source = "../../../aws//cdn"
+}
+
+dependencies {
+  paths = ["../route53"]
+}
+
+dependency "route53" {
+  config_path = "../route53"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    hosted_zone_id = "Z001234567890ABCDEFGHIJ"
+  }
+}
+
+inputs = {
+  hosted_zone_id = dependency.route53.outputs.hosted_zone_id
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Add the CloudFront distribution and S3 bucket that will be used by the CDN.

# Related
- cds-snc/platform-core-services#322