### PR TITLE
feat: add A record for CloudFront distribution

### DIFF
--- a/terragrunt/aws/cdn/route53.tf
+++ b/terragrunt/aws/cdn/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "cdn_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_cdn
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
# Summary
Add the `A` record for the CDN's URL that points to the CloudFront distribution.

# :warning: Note
This was applied locally to test.

# Related
- cds-snc/platform-core-services#322