### PR TITLE
fix: Terraform module reference

### DIFF
--- a/terragrunt/aws/cdn/s3.tf
+++ b/terragrunt/aws/cdn/s3.tf
@@ -1,5 +1,5 @@
 module "cdn_origin" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.1"
   bucket_name       = "${var.product_name}-${var.env}-cdn"
   billing_tag_value = var.billing_code
 


### PR DESCRIPTION
# Summary
Update the version reference for the Terraform modules to be after the module sub-directory.