### PR TITLE
fix: hosted zone outputs

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -45,3 +45,9 @@ jobs:
       - name: Apply website
         working-directory: terragrunt/env/production/website
         run: terragrunt apply --terragrunt-non-interactive -auto-approve        
+
+      - name: Slack message on failure
+        if: failure()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <https://github.com/cds-snc/gcds-terraform/actions/workflows/terraform-apply-production.yml|Terraform apply production>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}  

--- a/terragrunt/env/production/website/terragrunt.hcl
+++ b/terragrunt/env/production/website/terragrunt.hcl
@@ -12,14 +12,14 @@ dependency "route53" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    hosted_zone_id_en = "Z001234567890ABCDEFGHIJ"
-    hosted_zone_id_fr = "Z001234567890ABCDEFGHIJ"
+    hosted_zone_id_website_en = "Z001234567890ABCDEFGHIJ"
+    hosted_zone_id_website_fr = "Z001234567890ABCDEFGHIJ"
   }
 }
 
 inputs = {
-  hosted_zone_id_en = dependency.route53.outputs.hosted_zone_id_en
-  hosted_zone_id_fr = dependency.route53.outputs.hosted_zone_id_fr
+  hosted_zone_id_en = dependency.route53.outputs.hosted_zone_id_website_en
+  hosted_zone_id_fr = dependency.route53.outputs.hosted_zone_id_website_fr
 }
 
 include {


### PR DESCRIPTION
# Summary
Update the `website` module to use the correct `hosted_zone` outputs.

This also adds a step to the TF apply workflow that will post a message to the `#ds-cds-ops` channel if the workflow fails.

# Related
- https://github.com/cds-snc/design-gc-conception/issues/549
- https://github.com/cds-snc/platform-core-services/issues/476