### PR TITLE
feat: add amplify terraform files

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.6.1
   TERRAGRUNT_VERSION: 0.52.1
+  TF_VAR_gh_access_token: ${{ secrets.GH_ACCESS_TOKEN }}
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -11,6 +11,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.6.1
   TERRAGRUNT_VERSION: 0.52.1
+  TF_VAR_gh_access_token: ${{ secrets.GH_ACCESS_TOKEN }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -1,5 +1,5 @@
 resource "aws_amplify_app" "design_system_docs" {
-  name = "Design System"
+  name       = "Design System"
   repository = "https://github.com/cds-snc/gcds-docs"
 
   # Github personal access token

--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -1,0 +1,44 @@
+resource "aws_amplify_app" "design_system_docs" {
+  name = "Design System"
+  repository = "https://github.com/cds-snc/gcds-docs"
+
+  # Github personal access token
+  # -- needed when setting up amplify or making changes
+  access_token = var.gh_access_token
+
+  build_spec = <<-EOT
+    version: 1
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - npm install
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        # IMPORTANT - Please verify your build output directory
+        baseDirectory: _site/
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+  EOT
+
+  # The default rewrites and redirects added by the Amplify Console.
+  custom_rule {
+    source = "/<*>"
+    status = "404"
+    target = "/index.html"
+  }
+
+
+  auto_branch_creation_config {
+    # Enable auto build for the created branch.
+    enable_auto_build             = true
+    enable_pull_request_preview   = true
+    pull_request_environment_name = "rc"
+    stage                         = "PRODUCTION"
+  }
+}

--- a/terragrunt/aws/website/inputs.tf
+++ b/terragrunt/aws/website/inputs.tf
@@ -7,3 +7,8 @@ variable "hosted_zone_id_fr" {
   description = "The ID of the Route53 hosted zone to create the website's French DNS records in"
   type        = string
 }
+
+variable "gh_access_token" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
# Summary | Résumé

Initial files for setting up amplify
`amplify.tf` would need the `gh_access_token` I created and placed under Settings > Secrets > Actions

# Related
- https://github.com/cds-snc/design-gc-conception/issues/549