### PR TITLE
fix: update amplify to add domains and move build spec into a file

### DIFF
--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -6,25 +6,7 @@ resource "aws_amplify_app" "design_system_docs" {
   # -- needed when setting up amplify or making changes
   access_token = var.gh_access_token
 
-  build_spec = <<-EOT
-    version: 1
-    frontend:
-      phases:
-        preBuild:
-          commands:
-            - npm install
-        build:
-          commands:
-            - npm run build
-      artifacts:
-        # IMPORTANT - Please verify your build output directory
-        baseDirectory: _site/
-        files:
-          - '**/*'
-      cache:
-        paths:
-          - node_modules/**/*
-  EOT
+  build_spec = file("${path.module}/build_spec/amplify.yml")
 
   # The default rewrites and redirects added by the Amplify Console.
   custom_rule {
@@ -33,6 +15,19 @@ resource "aws_amplify_app" "design_system_docs" {
     target = "/index.html"
   }
 
+  # Redirect for english website
+  custom_rule {
+    source = var.domain_website_en
+    status = "302"
+    target = var.domain_website_en + "/en"
+  }
+
+  # Redirect for french website
+  custom_rule {
+    source = var.domain_website_fr
+    status = "302"
+    target = var.domain_website_fr + "/fr"
+  }
 
   auto_branch_creation_config {
     # Enable auto build for the created branch.
@@ -40,5 +35,53 @@ resource "aws_amplify_app" "design_system_docs" {
     enable_pull_request_preview   = true
     pull_request_environment_name = "rc"
     stage                         = "PRODUCTION"
+  }
+}
+
+resource "aws_amplify_branch" "main" {
+  app_id      = aws_amplify_app.design_system_docs.id
+  branch_name = "main"
+
+  # Could be one of: PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL, PULL_REQUEST
+  stage = "PRODUCTION"
+
+  display_name = "production"
+
+  enable_pull_request_preview = false
+}
+
+resource "aws_amplify_domain_association" "design_system_en" {
+
+  app_id      = aws_amplify_app.design_system_docs.id
+  domain_name = var.domain_website_en
+
+  wait_for_verification = false
+
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = ""
+  }
+
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = "www"
+  }
+}
+
+resource "aws_amplify_domain_association" "design_system_fr" {
+
+  app_id      = aws_amplify_app.design_system_docs.id
+  domain_name = var.domain_website_fr
+
+  wait_for_verification = false
+
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = ""
+  }
+
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = "www"
   }
 }

--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -19,14 +19,14 @@ resource "aws_amplify_app" "design_system_docs" {
   custom_rule {
     source = var.domain_website_en
     status = "302"
-    target = var.domain_website_en + "/en"
+    target = "${var.domain}/en"
   }
 
   # Redirect for french website
   custom_rule {
     source = var.domain_website_fr
     status = "302"
-    target = var.domain_website_fr + "/fr"
+    target = "${var.domain}/fr"
   }
 
   auto_branch_creation_config {

--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -51,7 +51,6 @@ resource "aws_amplify_branch" "main" {
 }
 
 resource "aws_amplify_domain_association" "design_system_en" {
-
   app_id      = aws_amplify_app.design_system_docs.id
   domain_name = var.domain_website_en
 
@@ -69,7 +68,6 @@ resource "aws_amplify_domain_association" "design_system_en" {
 }
 
 resource "aws_amplify_domain_association" "design_system_fr" {
-
   app_id      = aws_amplify_app.design_system_docs.id
   domain_name = var.domain_website_fr
 

--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -19,14 +19,14 @@ resource "aws_amplify_app" "design_system_docs" {
   custom_rule {
     source = var.domain_website_en
     status = "302"
-    target = "${var.domain}/en"
+    target = "${var.domain_website_en}/en"
   }
 
   # Redirect for french website
   custom_rule {
     source = var.domain_website_fr
     status = "302"
-    target = "${var.domain}/fr"
+    target = "${var.domain_website_fr}/fr"
   }
 
   auto_branch_creation_config {

--- a/terragrunt/aws/website/build_spec/amplify.yml
+++ b/terragrunt/aws/website/build_spec/amplify.yml
@@ -1,0 +1,17 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm install
+    build:
+      commands:
+        - npm run build
+  artifacts:
+    # IMPORTANT - Please verify your build output directory
+    baseDirectory: _site/
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*


### PR DESCRIPTION
# Summary | Résumé
- Adds the english and french domains and their corresponding rewrites
- Moves the build spec into a yaml file
- Adds main GH branch to amplify config