### PR TITLE
feat: add path to api from amplify rewrites & redirects

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -43,13 +43,13 @@ jobs:
       - name: Apply CDN
         working-directory: terragrunt/env/production/cdn
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
-        
-      - name: Apply website
-        working-directory: terragrunt/env/production/website
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
-      
+
       - name: Apply API
         working-directory: terragrunt/env/production/api
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply website
+        working-directory: terragrunt/env/production/website
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Slack message on failure

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - module: website
           - module: cdn
           - module: route53
-          - module: api 
+          - module: api
+          - module: website
 
     runs-on: ubuntu-latest
     steps:

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -1,4 +1,5 @@
 output "function_url" {
   description = "The URL of the Lambda function"
   value       = aws_lambda_function_url.api.function_url
+  sensitive   = true
 }

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -1,0 +1,4 @@
+output "function_url" {
+  description = "The URL of the Lambda function"
+  value       = aws_lambda_function_url.api.function_url
+}

--- a/terragrunt/aws/website/amplify.tf
+++ b/terragrunt/aws/website/amplify.tf
@@ -28,6 +28,13 @@ resource "aws_amplify_app" "design_system_docs_en" {
     target = "/en/"
     status = "200"
   }
+
+  # Redirect for the API contact form submission
+  custom_rule {
+    source = "/api/submission"
+    target = "${var.api_function_url}submission"
+    status = "200"
+  }
 }
 
 resource "aws_amplify_app" "design_system_docs_fr" {
@@ -58,6 +65,13 @@ resource "aws_amplify_app" "design_system_docs_fr" {
   custom_rule {
     source = "/"
     target = "/fr/"
+    status = "200"
+  }
+
+  # Redirect for the API contact form submission
+  custom_rule {
+    source = "/api/submission"
+    target = "${var.api_function_url}submission"
     status = "200"
   }
 }

--- a/terragrunt/aws/website/inputs.tf
+++ b/terragrunt/aws/website/inputs.tf
@@ -16,4 +16,5 @@ variable "gh_access_token" {
 variable "api_function_url" {
   description = "The URL of the API lambda function"
   type        = string
+  sensitive   = true
 }

--- a/terragrunt/aws/website/inputs.tf
+++ b/terragrunt/aws/website/inputs.tf
@@ -12,3 +12,8 @@ variable "gh_access_token" {
   type      = string
   sensitive = true
 }
+
+variable "api_function_url" {
+  description = "The URL of the API lambda function"
+  type        = string
+}

--- a/terragrunt/env/production/website/terragrunt.hcl
+++ b/terragrunt/env/production/website/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../route53"]
+  paths = ["../route53", "../api"]
 }
 
 dependency "route53" {
@@ -17,9 +17,20 @@ dependency "route53" {
   }
 }
 
+dependency "api" {
+  config_path = "../api"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    api_function_url = "https://api.design-system.com"
+  }
+}
+
 inputs = {
   hosted_zone_id_en = dependency.route53.outputs.hosted_zone_id_website_en
   hosted_zone_id_fr = dependency.route53.outputs.hosted_zone_id_website_fr
+  api_function_url  = dependency.api.outputs.function_url
 }
 
 include {

--- a/terragrunt/env/production/website/terragrunt.hcl
+++ b/terragrunt/env/production/website/terragrunt.hcl
@@ -23,7 +23,7 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    api_function_url = "https://api.design-system.com"
+    function_url = "https://api.design-system.com"
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé
Adds a reverse proxy for `/api/submission` to the lambda function URL