### PR TITLE
fix: move CDN NS records to website_en

### DIFF
--- a/terragrunt/aws/route53/route53.tf
+++ b/terragrunt/aws/route53/route53.tf
@@ -29,13 +29,8 @@ resource "aws_route53_record" "cdn_NS" {
   zone_id = aws_route53_zone.website_en.zone_id
   name    = var.domain_cdn
 
-  type    = "NS"
+  type = "NS"
 
-  records = [
-    "ns-1114.awsdns-11.org",
-    "ns-830.awsdns-39.net",
-    "ns-2010.awsdns-59.co.uk",
-    "ns-111.awsdns-13.com"
-  ]
-  ttl = "300"
+  records = aws_route53_zone.content_delivery_network.name_servers
+  ttl     = "300"
 }

--- a/terragrunt/aws/route53/route53.tf
+++ b/terragrunt/aws/route53/route53.tf
@@ -24,3 +24,18 @@ resource "aws_route53_zone" "website_fr" {
     Terraform  = true
   }
 }
+
+resource "aws_route53_record" "cdn_NS" {
+  zone_id = aws_route53_zone.website_en.zone_id
+  name    = var.domain_cdn
+
+  type    = "NS"
+
+  records = [
+    "ns-1114.awsdns-11.org",
+    "ns-830.awsdns-39.net",
+    "ns-2010.awsdns-59.co.uk",
+    "ns-111.awsdns-13.com"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé
Step 2 - Moves CDN NS records to website_en hosted zone

⚠️ Make sure to run the currently failing terraform plan to have the `*.alpha.canada.ca` hosted zones in place first before merging