### PR TITLE
Adding alarms to alert on Errors and Warnings

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -14,6 +14,8 @@ env:
   TERRAGRUNT_VERSION: 0.52.1
   TF_VAR_gh_access_token: ${{ secrets.GH_ACCESS_TOKEN }}
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
+  TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -13,6 +13,8 @@ env:
   TERRAGRUNT_VERSION: 0.52.1
   TF_VAR_gh_access_token: ${{ secrets.GH_ACCESS_TOKEN }}
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
+  TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
 permissions:
   id-token: write

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -5,3 +5,4 @@ skip-check:
   - CKV_AWS_86  # CloudFront: Access logging not required
   - CKV_AWS_51 # ECR: `latest` tag is used for development
   - CKV_AWS_136 # ECR: default encryption key is acceptable
+  - CKV_AWS_26 # SNS: Encryption-at-rest not required for alarm topic 

--- a/terragrunt/aws/api/alarms.tf
+++ b/terragrunt/aws/api/alarms.tf
@@ -1,0 +1,57 @@
+resource "aws_cloudwatch_log_metric_filter" "gc_design_system_error" {
+  name           = local.error_logged
+  pattern        = "?ERROR ?Exception"
+  log_group_name = local.api_cloudwatch_log_group
+
+  metric_transformation {
+    name      = local.error_logged
+    namespace = local.error_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "gc_design_system_error" {
+  alarm_name          = "GC Design System Errors"
+  alarm_description   = "Errors logged by the GC Design System"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.gc_design_system_error.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.gc_design_system_error.metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = var.error_threshold
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "gc_design_system_warning" {
+  name           = local.warning_logged
+  pattern        = "WARNING"
+  log_group_name = local.api_cloudwatch_log_group
+
+  metric_transformation {
+    name      = local.warning_logged
+    namespace = local.error_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "gc_design_system_warning" {
+  alarm_name          = "GC Design System Warnings"
+  alarm_description   = "Warnings logged by the GC Design System"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.gc_design_system_warning.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.gc_design_system_warning.metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = var.warning_threshold
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}

--- a/terragrunt/aws/api/alarms.tf
+++ b/terragrunt/aws/api/alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "gc_design_system_error" {
   name           = local.error_logged
-  pattern        = "?ERROR ?Exception"
+  pattern        = "?ERROR ?Error"
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -3,3 +3,21 @@ variable "api_config" {
   type        = string
   sensitive   = true
 }
+
+variable "error_threshold" {
+  description = "CloudWatch alarm threshold for the GC Design System ERROR logs"
+  type        = string
+  default     = "1"
+}
+
+variable "warning_threshold" {
+  description = "CloudWatch alarm threshold for the GC Design System WARNING logs"
+  type        = string
+  default     = "10"
+}
+
+variable "slack_webhook_url" {
+  description = "The URL of the Slack webhook."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/api/local.tf
+++ b/terragrunt/aws/api/local.tf
@@ -1,0 +1,6 @@
+locals {
+  api_cloudwatch_log_group = "/aws/lambda/gc-design-system-api"
+  error_logged             = "GCDesignSystemErrorLogged"
+  error_namespace          = "GCDesignSystem"
+  warning_logged           = "GCDesignSystemWarningLogged"
+}

--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -1,0 +1,17 @@
+#
+# SNS: topic & subscription
+#
+resource "aws_sns_topic" "cloudwatch_warning" {
+  name = "gc-design-system-cloudwatch-alarms-warning"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_sns_topic_subscription" "alert_warning" {
+  topic_arn = aws_sns_topic.cloudwatch_warning.arn
+  protocol  = "https"
+  endpoint  = var.slack_webhook_url
+}


### PR DESCRIPTION
# Summary | Résumé

Added alarms to be sent to the #ds-cds-ops Slack channel whenever an Error or Warning is generated in the Cloudwatch Logs for the GC Design System Lambda function. I have added the secret value for SLACK_WEBHOOK_URL in the Github repo. 

This PR closes issue https://github.com/cds-snc/design-gc-conception/issues/735
