### PR TITLE
chore: update log retention period to 1 year

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -12,7 +12,7 @@ module "api" {
     data.aws_iam_policy_document.api_policies.json,
   ]
 
-  billing_tag_value = var.billing_code
+  billing_tag_value          = var.billing_code
   log_group_retention_period = 356
 }
 

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -13,6 +13,7 @@ module "api" {
   ]
 
   billing_tag_value = var.billing_code
+  log_group_retention_period = 356
 }
 
 resource "aws_lambda_function_url" "api" {

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -13,7 +13,7 @@ module "api" {
   ]
 
   billing_tag_value          = var.billing_code
-  log_group_retention_period = 356
+  log_group_retention_period = 365
 }
 
 resource "aws_lambda_function_url" "api" {


### PR DESCRIPTION
# Summary | Résumé
Updates the lambda logs retention period to 365 days instead of the default value of 14 days