### PR TITLE
ci: add new app for fable testing

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -54,6 +54,10 @@ jobs:
         working-directory: terragrunt/env/production/website
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Apply fable-test
+        working-directory: terragrunt/env/production/fable-test
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Slack message on failure
         if: failure()
         run: |

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -34,6 +34,7 @@ jobs:
           - module: route53
           - module: api
           - module: website
+          - module: fable-test
 
     runs-on: ubuntu-latest
     steps:

--- a/terragrunt/aws/fable-test/amplify.tf
+++ b/terragrunt/aws/fable-test/amplify.tf
@@ -1,0 +1,31 @@
+resource "aws_amplify_app" "design_system_fable_test_app" {
+  name       = "GCDS Canadian Holidays"
+  repository = "https://github.com/cds-snc/gcds-examples"
+
+  # Github personal access token
+  # -- needed when setting up amplify or making changes
+  access_token = var.gh_access_token
+
+  build_spec = file("${path.module}/build_spec/amplify.yml")
+
+  # 404 redirects
+  custom_rule {
+    source = "/<*>"
+    target = "/404"
+    status = "404"
+  }
+}
+
+
+resource "aws_amplify_branch" "main" {
+  app_id      = aws_amplify_app.design_system_fable_test_app.id
+  branch_name = "main"
+
+  # Could be one of: PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL, PULL_REQUEST
+  stage = "PRODUCTION"
+
+  display_name = "production"
+
+  # We only need one preview environment since it contains both english and french content
+  enable_pull_request_preview = true
+}

--- a/terragrunt/aws/fable-test/amplify.tf
+++ b/terragrunt/aws/fable-test/amplify.tf
@@ -17,7 +17,7 @@ resource "aws_amplify_app" "design_system_fable_test_app" {
 }
 
 
-resource "aws_amplify_branch" "main" {
+resource "aws_amplify_branch" "main_fable_test" {
   app_id      = aws_amplify_app.design_system_fable_test_app.id
   branch_name = "main"
 
@@ -26,6 +26,5 @@ resource "aws_amplify_branch" "main" {
 
   display_name = "production"
 
-  # We only need one preview environment since it contains both english and french content
   enable_pull_request_preview = true
 }

--- a/terragrunt/aws/fable-test/build_spec/amplify.yml
+++ b/terragrunt/aws/fable-test/build_spec/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        preBuild:
+          commands:
+            - npm ci --cache .npm --prefer-offline
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        baseDirectory: dist
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - .npm/**/*
+    appRoot: fable-test-app

--- a/terragrunt/aws/fable-test/inputs.tf
+++ b/terragrunt/aws/fable-test/inputs.tf
@@ -1,0 +1,4 @@
+variable "gh_access_token" {
+  type      = string
+  sensitive = true
+}

--- a/terragrunt/env/production/fable-test/terragrunt.hcl
+++ b/terragrunt/env/production/fable-test/terragrunt.hcl
@@ -1,0 +1,38 @@
+terraform {
+  source = "../../../aws//website"
+}
+
+dependencies {
+  paths = ["../route53", "../api"]
+}
+
+dependency "route53" {
+  config_path = "../route53"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    hosted_zone_id_website_en = "Z001234567890ABCDEFGHIJ"
+    hosted_zone_id_website_fr = "Z001234567890ABCDEFGHIJ"
+  }
+}
+
+dependency "api" {
+  config_path = "../api"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    function_url = "https://api.design-system.com"
+  }
+}
+
+inputs = {
+  hosted_zone_id_en = dependency.route53.outputs.hosted_zone_id_website_en
+  hosted_zone_id_fr = dependency.route53.outputs.hosted_zone_id_website_fr
+  api_function_url  = dependency.api.outputs.function_url
+}
+
+include {
+  path = find_in_parent_folders()
+}

--- a/terragrunt/env/production/fable-test/terragrunt.hcl
+++ b/terragrunt/env/production/fable-test/terragrunt.hcl
@@ -1,36 +1,5 @@
 terraform {
-  source = "../../../aws//website"
-}
-
-dependencies {
-  paths = ["../route53", "../api"]
-}
-
-dependency "route53" {
-  config_path = "../route53"
-
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs_merge_strategy_with_state  = "shallow"
-  mock_outputs = {
-    hosted_zone_id_website_en = "Z001234567890ABCDEFGHIJ"
-    hosted_zone_id_website_fr = "Z001234567890ABCDEFGHIJ"
-  }
-}
-
-dependency "api" {
-  config_path = "../api"
-
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs_merge_strategy_with_state  = "shallow"
-  mock_outputs = {
-    function_url = "https://api.design-system.com"
-  }
-}
-
-inputs = {
-  hosted_zone_id_en = dependency.route53.outputs.hosted_zone_id_website_en
-  hosted_zone_id_fr = dependency.route53.outputs.hosted_zone_id_website_fr
-  api_function_url  = dependency.api.outputs.function_url
+  source = "../../../aws//fable-test"
 }
 
 include {


### PR DESCRIPTION
# Summary | Résumé
Adds new amplify app for the Canadian Holidays app we're using for fable testing. At the moment, we'd like this app not to be indexed so there is no need for a domain for it.