### PR TITLE
fix: rewrites and redirects for a spa app

### DIFF
--- a/terragrunt/aws/fable-test/amplify.tf
+++ b/terragrunt/aws/fable-test/amplify.tf
@@ -8,11 +8,11 @@ resource "aws_amplify_app" "design_system_fable_test_app" {
 
   build_spec = file("${path.module}/build_spec/amplify.yml")
 
-  # 404 redirects
+  # The default rewrites and redirects for a single page app
   custom_rule {
     source = "/<*>"
-    target = "/404"
     status = "404"
+    target = "/index.html"
   }
 }
 

--- a/terragrunt/aws/fable-test/amplify.tf
+++ b/terragrunt/aws/fable-test/amplify.tf
@@ -25,6 +25,4 @@ resource "aws_amplify_branch" "main_fable_test" {
   stage = "PRODUCTION"
 
   display_name = "fable-test"
-
-  enable_pull_request_preview = true
 }

--- a/terragrunt/aws/fable-test/amplify.tf
+++ b/terragrunt/aws/fable-test/amplify.tf
@@ -11,7 +11,7 @@ resource "aws_amplify_app" "design_system_fable_test_app" {
   # The default rewrites and redirects for a single page app
   custom_rule {
     source = "/<*>"
-    status = "404"
+    status = "404-200"
     target = "/index.html"
   }
 }


### PR DESCRIPTION
# Summary | Résumé
Fix the rewrites for a single page application. This change has already been applied on AWS --- hopefully terraform plan shows 0 changes for this part.

Also, let's turn off the pull request previews for now. Having it enabled will add a preview environment for all our PRs on `gcds-examples`, not just fable app. If we moved the branch of the fable testing app to something other than `main`, we can put it back in again.
I'm only expecting terraform to have 1 change -- to turn off pull request previews