### PR TITLE
Encrypting SNS topic as is required for the 30 day guardrails

### DIFF
--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -3,6 +3,7 @@
 #
 resource "aws_sns_topic" "cloudwatch_warning" {
   name = "gc-design-system-cloudwatch-alarms-warning"
+  kms_master_key_id = aws_kms_key.sns_cloudwatch.id
 
   tags = {
     CostCentre = var.billing_code
@@ -14,4 +15,39 @@ resource "aws_sns_topic_subscription" "alert_warning" {
   topic_arn = aws_sns_topic.cloudwatch_warning.arn
   protocol  = "https"
   endpoint  = var.slack_webhook_url
+}
+
+# KMS Key for SNS CloudWatch topic
+# This key is used to encrypt messages sent to the SNS topic for CloudWatch alarms.
+resource "aws_kms_key" "sns_cloudwatch" {
+  description = "KMS key for CloudWatch SNS topic"
+  policy      = data.aws_iam_policy_document.sns_cloudwatch.json
+}
+
+# IAM policy document for the KMS key used by SNS CloudWatch topic
+data "aws_iam_policy_document" "sns_cloudwatch" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+  }
 }


### PR DESCRIPTION
# Summary | Résumé

This PR encrypts the SNS topic with a KMS Key and assigns a policy giving permission for Cloudwatch to be able to encrypt and decrypt with the KMS key.

This is a requirement for the 30 day guardrails that we will need to implement. 
