### PR TITLE
fix: replicate CloudFront logs to Platform Data Lake

### DIFF
--- a/terragrunt/aws/cdn/cloudfront.tf
+++ b/terragrunt/aws/cdn/cloudfront.tf
@@ -37,7 +37,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   logging_config {
     bucket = module.cloudfront_logs.s3_bucket_domain_name
-    prefix = "cloudfront-logs/"
+    prefix = "platform/gc-design-system/cloudfront-logs/"
   }
 
   viewer_certificate {

--- a/terragrunt/aws/cdn/inputs.tf
+++ b/terragrunt/aws/cdn/inputs.tf
@@ -2,3 +2,8 @@ variable "hosted_zone_id" {
   description = "The hosted zone ID for the CDN DNS records"
   type        = string
 }
+
+variable "platform_data_lake_raw_s3_bucket_arn" {
+  description = "The ARN of the S3 bucket for the Platform Data Lake raw storage"
+  type        = string
+}

--- a/terragrunt/env/production/cdn/terragrunt.hcl
+++ b/terragrunt/env/production/cdn/terragrunt.hcl
@@ -17,7 +17,8 @@ dependency "route53" {
 }
 
 inputs = {
-  hosted_zone_id = dependency.route53.outputs.hosted_zone_id_cdn
+  hosted_zone_id                       = dependency.route53.outputs.hosted_zone_id_cdn
+  platform_data_lake_raw_s3_bucket_arn = "arn:aws:s3:::cds-data-lake-raw-production"
 }
 
 include {


### PR DESCRIPTION
# Summary
Replicated CloudFront access logs to the Platform Data Lake.  These will be used to calculate the stats that are currently bundled in the popular cache object and request data CSVs that are only available for download in the AWS console.

As part of this change, the log S3 prefix is being updated so that when the objects replicate to the Raw bucket, they will be correctly organized with the other Platform product data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/797