### PR TITLE
chore: add policy arn to get object

### DIFF
--- a/terragrunt/aws/cdn/s3.tf
+++ b/terragrunt/aws/cdn/s3.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "cloudfront_get_object" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.cdn.iam_arn]
+      identifiers = [aws_cloudfront_origin_access_identity.cdn.iam_arn, aws_cloudfront_origin_access_identity.ca_cdn.iam_arn]
     }
     actions = [
       "s3:GetObject",


### PR DESCRIPTION
# Summary | Résumé
Getting an access denied issue -- adding the ca_cdn policy to the getobject policy for the cdn s3 bucket