### PR TITLE
chore: add amplify_waf.tf

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,8 +1,9 @@
 skip-check:
   - CKV2_AWS_32 # CloudFront: CDN appropriate response headers policy has been applied
   - CKV2_AWS_38 # Route53: DNS Secruity Extensions (DNSSEC) signing not required
-  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
+  - CKV2_AWS_31 # WAF metrics monitored via CloudWatch is acceptable  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
   - CKV_AWS_86  # CloudFront: Access logging not required
   - CKV_AWS_51 # ECR: `latest` tag is used for development
   - CKV_AWS_136 # ECR: default encryption key is acceptable
-  - CKV_AWS_26 # SNS: Encryption-at-rest not required for alarm topic 
+  - CKV_AWS_26 # SNS: Encryption-at-rest not required for alarm topic
+  - CKV_AWS_158 # CloudWatch log group default service key encryption is acceptable

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,7 +1,6 @@
 skip-check:
   - CKV2_AWS_32 # CloudFront: CDN appropriate response headers policy has been applied
   - CKV2_AWS_38 # Route53: DNS Secruity Extensions (DNSSEC) signing not required
-  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
   - CKV_AWS_86  # CloudFront: Access logging not required
   - CKV_AWS_51 # ECR: `latest` tag is used for development
   - CKV_AWS_136 # ECR: default encryption key is acceptable

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,6 +1,7 @@
 skip-check:
   - CKV2_AWS_32 # CloudFront: CDN appropriate response headers policy has been applied
   - CKV2_AWS_38 # Route53: DNS Secruity Extensions (DNSSEC) signing not required
+  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
   - CKV_AWS_86  # CloudFront: Access logging not required
   - CKV_AWS_51 # ECR: `latest` tag is used for development
   - CKV_AWS_136 # ECR: default encryption key is acceptable

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,9 +1,10 @@
 skip-check:
   - CKV2_AWS_32 # CloudFront: CDN appropriate response headers policy has been applied
   - CKV2_AWS_38 # Route53: DNS Secruity Extensions (DNSSEC) signing not required
-  - CKV2_AWS_31 # WAF metrics monitored via CloudWatch is acceptable  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
+  - CKV_AWS_68  # CloudFront: WAF ACL not required for the CDN
   - CKV_AWS_86  # CloudFront: Access logging not required
   - CKV_AWS_51 # ECR: `latest` tag is used for development
   - CKV_AWS_136 # ECR: default encryption key is acceptable
   - CKV_AWS_26 # SNS: Encryption-at-rest not required for alarm topic
-  - CKV_AWS_158 # CloudWatch log group default service key encryption is acceptable
+  - CKV2_AWS_31 # WAF metrics monitored via CloudWatch is acceptable
+  - CKV_AWS_158 # CloudWatch Logs: KMS encryption not required for WAF metrics

--- a/terragrunt/aws/website/amplify_waf.tf
+++ b/terragrunt/aws/website/amplify_waf.tf
@@ -529,3 +529,37 @@ resource "aws_wafv2_web_acl_association" "amplify_fr" {
   resource_arn = aws_amplify_app.design_system_docs_fr.arn
   web_acl_arn  = aws_wafv2_web_acl.amplify_fr.arn
 }
+
+resource "aws_cloudwatch_log_group" "waf_amplify_en" {
+  provider          = aws.us-east-1
+  name              = "aws-waf-logs-${var.product_name}-amplify-en-${var.env}"
+  retention_in_days = 90
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "waf_amplify_fr" {
+  provider          = aws.us-east-1
+  name              = "aws-waf-logs-${var.product_name}-amplify-fr-${var.env}"
+  retention_in_days = 90
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "amplify_en" {
+  provider                = aws.us-east-1
+  resource_arn            = aws_wafv2_web_acl.amplify_en.arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf_amplify_en.arn]
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "amplify_fr" {
+  provider                = aws.us-east-1
+  resource_arn            = aws_wafv2_web_acl.amplify_fr.arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf_amplify_fr.arn]
+}

--- a/terragrunt/aws/website/amplify_waf.tf
+++ b/terragrunt/aws/website/amplify_waf.tf
@@ -1,7 +1,7 @@
 # WAF ACL for Design System Documentation (EN)
-resource "aws_wafv2_web_acl" "amplify_en" {
+resource "aws_wafv2_web_acl" "amplify_docs" {
   provider = aws.us-east-1
-  name     = "waf-${var.product_name}-amplify-en-${var.env}"
+  name     = "waf-${var.product_name}-amplify-docs-${var.env}"
   scope    = "CLOUDFRONT"
 
   default_action {
@@ -26,7 +26,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-en-common-rules"
+      metric_name                = "${var.product_name}-amplify-docs-common-rules"
       sampled_requests_enabled   = true
     }
   }
@@ -49,12 +49,12 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-en-known-bad-inputs"
+      metric_name                = "${var.product_name}-amplify-docs-known-bad-inputs"
       sampled_requests_enabled   = true
     }
   }
 
-  # Rate Limiting Rule (only POST to /api/submission/)
+  # Rate Limiting Rule (only POST to /api/submission)
   rule {
     name     = "RateLimitRule"
     priority = 2
@@ -65,7 +65,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     statement {
       rate_based_statement {
-        limit              = 1000
+        limit              = 100
         aggregate_key_type = "IP"
 
         scope_down_statement {
@@ -75,7 +75,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
                 field_to_match {
                   uri_path {}
                 }
-                regex_string = "^/api/submission/$"
+                regex_string = "^/api/submission(/.*)?$"
                 text_transformation {
                   priority = 0
                   type     = "LOWERCASE"
@@ -102,7 +102,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-en-rate-limit"
+      metric_name                = "${var.product_name}-amplify-docs-rate-limit"
       sampled_requests_enabled   = true
     }
   }
@@ -134,12 +134,12 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-en-block-large-requests"
-      sampled_requests_enabled   = false
+      metric_name                = "${var.product_name}-amplify-docs-block-large-requests"
+      sampled_requests_enabled   = true
     }
   }
 
-  # Only allow POST on /api/submission/
+  # Only allow POST on /api/submission
   rule {
     name     = "SubmissionMethodRestriction"
     priority = 4
@@ -152,7 +152,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
       and_statement {
         statement {
           regex_match_statement {
-            regex_string = "^/api/submission/$"
+            regex_string = "^/api/submission(/.*)?$"
             field_to_match {
               uri_path {}
             }
@@ -168,13 +168,13 @@ resource "aws_wafv2_web_acl" "amplify_en" {
             statement {
               byte_match_statement {
                 positional_constraint = "EXACTLY"
-                search_string         = "POST"
+                search_string         = "post"
                 field_to_match {
                   method {}
                 }
                 text_transformation {
                   priority = 0
-                  type     = "NONE"
+                  type     = "LOWERCASE"
                 }
               }
             }
@@ -185,12 +185,12 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-en-submission-method-restriction"
+      metric_name                = "${var.product_name}-amplify-docs-submission-method-restriction"
       sampled_requests_enabled   = true
     }
   }
 
-  # API Endpoint Protection - Whitelist known good paths (/api/submission/) and block everything else under /api/
+  # API Endpoint Protection - Whitelist known good paths (/api/submission) and block everything else under /api/
   rule {
     name     = "APIEndpointProtection"
     priority = 5
@@ -223,7 +223,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
           not_statement {
             statement {
               regex_match_statement {
-                regex_string = "^/api/submission/$"
+                regex_string = "^/api/submission(/.*)?$"
                 field_to_match {
                   uri_path {}
                 }
@@ -240,273 +240,14 @@ resource "aws_wafv2_web_acl" "amplify_en" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "APIEndpointProtection"
+      metric_name                = "${var.product_name}-amplify-docs-api-endpoint-protection"
       sampled_requests_enabled   = true
     }
   }
 
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                = "${var.product_name}-amplify-en"
-    sampled_requests_enabled   = true
-  }
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-# WAF ACL for Design System Documentation (FR)
-resource "aws_wafv2_web_acl" "amplify_fr" {
-  provider = aws.us-east-1
-  name     = "waf-${var.product_name}-amplify-fr-${var.env}"
-  scope    = "CLOUDFRONT"
-
-  default_action {
-    allow {}
-  }
-
-  # AWS Managed Rules - Common Rule Set
-  rule {
-    name     = "AWSManagedRulesCommonRuleSet"
-    priority = 0
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesCommonRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-fr-common-rules"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # AWS managed bad input protections (includes Log4j-style payload detection)
-  rule {
-    name     = "AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 1
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesKnownBadInputsRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-fr-known-bad-inputs"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # Rate Limiting Rule (only POST to /api/submission/)
-  rule {
-    name     = "RateLimitRule"
-    priority = 2
-
-    action {
-      block {}
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = 1000
-        aggregate_key_type = "IP"
-
-        scope_down_statement {
-          and_statement {
-            statement {
-              regex_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                regex_string = "^/api/submission/$"
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-
-            statement {
-              regex_match_statement {
-                field_to_match {
-                  method {}
-                }
-                regex_string = "^post$"
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-fr-rate-limit"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # Block large requests to prevent abuse and DoS attacks
-  rule {
-    name     = "BlockLargeRequests"
-    priority = 3
-
-    action {
-      block {}
-    }
-
-    statement {
-      size_constraint_statement {
-        field_to_match {
-          body {
-            oversize_handling = "MATCH"
-          }
-        }
-        comparison_operator = "GT"
-        size                = 20480 # 20 KB
-        text_transformation {
-          priority = 0
-          type     = "NONE"
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-fr-block-large-requests"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # Only allow POST on /api/submission/
-  rule {
-    name     = "SubmissionMethodRestriction"
-    priority = 4
-
-    action {
-      block {}
-    }
-
-    statement {
-      and_statement {
-        statement {
-          regex_match_statement {
-            regex_string = "^/api/submission/$"
-            field_to_match {
-              uri_path {}
-            }
-            text_transformation {
-              priority = 0
-              type     = "LOWERCASE"
-            }
-          }
-        }
-
-        statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                positional_constraint = "EXACTLY"
-                search_string         = "POST"
-                field_to_match {
-                  method {}
-                }
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-fr-submission-method-restriction"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # API Endpoint Protection - Whitelist known good paths (/api/submission/) and block everything else under /api/
-  rule {
-    name     = "APIEndpointProtection"
-    priority = 5
-
-    action {
-      block {
-        custom_response {
-          response_code = 403
-        }
-      }
-    }
-
-    statement {
-      and_statement {
-        statement {
-          byte_match_statement {
-            positional_constraint = "STARTS_WITH"
-            field_to_match {
-              uri_path {}
-            }
-            search_string = "/api/"
-            text_transformation {
-              priority = 0
-              type     = "LOWERCASE"
-            }
-          }
-        }
-
-        statement {
-          not_statement {
-            statement {
-              regex_match_statement {
-                regex_string = "^/api/submission/$"
-                field_to_match {
-                  uri_path {}
-                }
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.product_name}-amplify-fr-api-protection"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "${var.product_name}-amplify-fr"
+    metric_name                = "${var.product_name}-amplify-docs"
     sampled_requests_enabled   = true
   }
 
@@ -520,13 +261,13 @@ resource "aws_wafv2_web_acl" "amplify_fr" {
 resource "aws_wafv2_web_acl_association" "amplify_en" {
   provider     = aws.us-east-1
   resource_arn = aws_amplify_app.design_system_docs_en.arn
-  web_acl_arn  = aws_wafv2_web_acl.amplify_en.arn
+  web_acl_arn  = aws_wafv2_web_acl.amplify_docs.arn
 }
 
-# Associate WAF ACL with Amplify FR app
+# Associate the same WAF ACL with Amplify FR app
 resource "aws_wafv2_web_acl_association" "amplify_fr" {
   provider     = aws.us-east-1
   resource_arn = aws_amplify_app.design_system_docs_fr.arn
-  web_acl_arn  = aws_wafv2_web_acl.amplify_fr.arn
+  web_acl_arn  = aws_wafv2_web_acl.amplify_docs.arn
 }
 

--- a/terragrunt/aws/website/amplify_waf.tf
+++ b/terragrunt/aws/website/amplify_waf.tf
@@ -31,10 +31,33 @@ resource "aws_wafv2_web_acl" "amplify_en" {
     }
   }
 
+  # AWS managed bad input protections (includes Log4j-style payload detection)
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-en-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # Rate Limiting Rule (only POST to /api/submission/)
   rule {
     name     = "RateLimitRule"
-    priority = 1
+    priority = 2
 
     action {
       block {}
@@ -87,7 +110,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
   # Block large requests to prevent abuse and DoS attacks
   rule {
     name     = "BlockLargeRequests"
-    priority = 2
+    priority = 3
 
     action {
       block {}
@@ -119,7 +142,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
   # Only allow POST on /api/submission/
   rule {
     name     = "SubmissionMethodRestriction"
-    priority = 3
+    priority = 4
 
     action {
       block {}
@@ -170,7 +193,7 @@ resource "aws_wafv2_web_acl" "amplify_en" {
   # API Endpoint Protection - Whitelist known good paths (/api/submission/) and block everything else under /api/
   rule {
     name     = "APIEndpointProtection"
-    priority = 4
+    priority = 5
 
     action {
       block {
@@ -267,10 +290,33 @@ resource "aws_wafv2_web_acl" "amplify_fr" {
     }
   }
 
+  # AWS managed bad input protections (includes Log4j-style payload detection)
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-fr-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # Rate Limiting Rule (only POST to /api/submission/)
   rule {
     name     = "RateLimitRule"
-    priority = 1
+    priority = 2
 
     action {
       block {}
@@ -323,7 +369,7 @@ resource "aws_wafv2_web_acl" "amplify_fr" {
   # Block large requests to prevent abuse and DoS attacks
   rule {
     name     = "BlockLargeRequests"
-    priority = 2
+    priority = 3
 
     action {
       block {}
@@ -355,7 +401,7 @@ resource "aws_wafv2_web_acl" "amplify_fr" {
   # Only allow POST on /api/submission/
   rule {
     name     = "SubmissionMethodRestriction"
-    priority = 3
+    priority = 4
 
     action {
       block {}
@@ -406,7 +452,7 @@ resource "aws_wafv2_web_acl" "amplify_fr" {
   # API Endpoint Protection - Whitelist known good paths (/api/submission/) and block everything else under /api/
   rule {
     name     = "APIEndpointProtection"
-    priority = 4
+    priority = 5
 
     action {
       block {

--- a/terragrunt/aws/website/amplify_waf.tf
+++ b/terragrunt/aws/website/amplify_waf.tf
@@ -472,14 +472,14 @@ resource "aws_wafv2_web_acl" "amplify_fr" {
 
 # Associate WAF ACL with Amplify EN app
 resource "aws_wafv2_web_acl_association" "amplify_en" {
-  provider    = aws.us-east-1
+  provider     = aws.us-east-1
   resource_arn = aws_amplify_app.design_system_docs_en.arn
-  web_acl_arn = aws_wafv2_web_acl.amplify_en.arn
+  web_acl_arn  = aws_wafv2_web_acl.amplify_en.arn
 }
 
 # Associate WAF ACL with Amplify FR app
 resource "aws_wafv2_web_acl_association" "amplify_fr" {
-  provider    = aws.us-east-1
+  provider     = aws.us-east-1
   resource_arn = aws_amplify_app.design_system_docs_fr.arn
-  web_acl_arn = aws_wafv2_web_acl.amplify_fr.arn
+  web_acl_arn  = aws_wafv2_web_acl.amplify_fr.arn
 }

--- a/terragrunt/aws/website/amplify_waf.tf
+++ b/terragrunt/aws/website/amplify_waf.tf
@@ -530,36 +530,3 @@ resource "aws_wafv2_web_acl_association" "amplify_fr" {
   web_acl_arn  = aws_wafv2_web_acl.amplify_fr.arn
 }
 
-resource "aws_cloudwatch_log_group" "waf_amplify_en" {
-  provider          = aws.us-east-1
-  name              = "aws-waf-logs-${var.product_name}-amplify-en-${var.env}"
-  retention_in_days = 90
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_cloudwatch_log_group" "waf_amplify_fr" {
-  provider          = aws.us-east-1
-  name              = "aws-waf-logs-${var.product_name}-amplify-fr-${var.env}"
-  retention_in_days = 90
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_wafv2_web_acl_logging_configuration" "amplify_en" {
-  provider                = aws.us-east-1
-  resource_arn            = aws_wafv2_web_acl.amplify_en.arn
-  log_destination_configs = [aws_cloudwatch_log_group.waf_amplify_en.arn]
-}
-
-resource "aws_wafv2_web_acl_logging_configuration" "amplify_fr" {
-  provider                = aws.us-east-1
-  resource_arn            = aws_wafv2_web_acl.amplify_fr.arn
-  log_destination_configs = [aws_cloudwatch_log_group.waf_amplify_fr.arn]
-}

--- a/terragrunt/aws/website/amplify_waf.tf
+++ b/terragrunt/aws/website/amplify_waf.tf
@@ -1,0 +1,485 @@
+# WAF ACL for Design System Documentation (EN)
+resource "aws_wafv2_web_acl" "amplify_en" {
+  provider = aws.us-east-1
+  name     = "waf-${var.product_name}-amplify-en-${var.env}"
+  scope    = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # AWS Managed Rules - Common Rule Set (common vulnerabilities and bad bot protection)
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-en-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rate Limiting Rule (only POST to /api/submission/)
+  rule {
+    name     = "RateLimitRule"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 1000
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          and_statement {
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                regex_string = "^/api/submission/$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  method {}
+                }
+                regex_string = "^post$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-en-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Block large requests to prevent abuse and DoS attacks
+  rule {
+    name     = "BlockLargeRequests"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      size_constraint_statement {
+        field_to_match {
+          body {
+            oversize_handling = "MATCH"
+          }
+        }
+        comparison_operator = "GT"
+        size                = 20480 # 20 KB
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-en-block-large-requests"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  # Only allow POST on /api/submission/
+  rule {
+    name     = "SubmissionMethodRestriction"
+    priority = 3
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          regex_match_statement {
+            regex_string = "^/api/submission/$"
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                search_string         = "POST"
+                field_to_match {
+                  method {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-en-submission-method-restriction"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # API Endpoint Protection - Whitelist known good paths (/api/submission/) and block everything else under /api/
+  rule {
+    name     = "APIEndpointProtection"
+    priority = 4
+
+    action {
+      block {
+        custom_response {
+          response_code = 403
+        }
+      }
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/api/"
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              regex_match_statement {
+                regex_string = "^/api/submission/$"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "APIEndpointProtection"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.product_name}-amplify-en"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+# WAF ACL for Design System Documentation (FR)
+resource "aws_wafv2_web_acl" "amplify_fr" {
+  provider = aws.us-east-1
+  name     = "waf-${var.product_name}-amplify-fr-${var.env}"
+  scope    = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # AWS Managed Rules - Common Rule Set
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-fr-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rate Limiting Rule (only POST to /api/submission/)
+  rule {
+    name     = "RateLimitRule"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 1000
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          and_statement {
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                regex_string = "^/api/submission/$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  method {}
+                }
+                regex_string = "^post$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-fr-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Block large requests to prevent abuse and DoS attacks
+  rule {
+    name     = "BlockLargeRequests"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      size_constraint_statement {
+        field_to_match {
+          body {
+            oversize_handling = "MATCH"
+          }
+        }
+        comparison_operator = "GT"
+        size                = 20480 # 20 KB
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-fr-block-large-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Only allow POST on /api/submission/
+  rule {
+    name     = "SubmissionMethodRestriction"
+    priority = 3
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          regex_match_statement {
+            regex_string = "^/api/submission/$"
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                search_string         = "POST"
+                field_to_match {
+                  method {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-fr-submission-method-restriction"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # API Endpoint Protection - Whitelist known good paths (/api/submission/) and block everything else under /api/
+  rule {
+    name     = "APIEndpointProtection"
+    priority = 4
+
+    action {
+      block {
+        custom_response {
+          response_code = 403
+        }
+      }
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/api/"
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              regex_match_statement {
+                regex_string = "^/api/submission/$"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.product_name}-amplify-fr-api-protection"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.product_name}-amplify-fr"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+# Associate WAF ACL with Amplify EN app
+resource "aws_wafv2_web_acl_association" "amplify_en" {
+  provider    = aws.us-east-1
+  resource_arn = aws_amplify_app.design_system_docs_en.arn
+  web_acl_arn = aws_wafv2_web_acl.amplify_en.arn
+}
+
+# Associate WAF ACL with Amplify FR app
+resource "aws_wafv2_web_acl_association" "amplify_fr" {
+  provider    = aws.us-east-1
+  resource_arn = aws_amplify_app.design_system_docs_fr.arn
+  web_acl_arn = aws_wafv2_web_acl.amplify_fr.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Adds an AWS WAF Web ACL to the Amplify applications to improve protection against abusive or malicious traffic.

The Web ACL introduces baseline protections using AWS managed rule groups and custom rules to limit abuse of the `/api/submission` endpoint.